### PR TITLE
Fixes all bugs caused by the 'cif' column rename in Organization Table

### DIFF
--- a/tntconcept-web/src/main/resources/com/autentia/tnt/report/general/subreports/ourOrganizationName_subreport.jrxml
+++ b/tntconcept-web/src/main/resources/com/autentia/tnt/report/general/subreports/ourOrganizationName_subreport.jrxml
@@ -43,12 +43,12 @@
 	<import value="net.sf.jasperreports.engine.data.*" />
 
 	<parameter name="idOrg" isForPrompting="true" class="java.lang.Integer"/>
-	<queryString><![CDATA[select name,cif,phone,street,number,locator,city,postalCode,email,website 
+	<queryString><![CDATA[select name,documentNumber,phone,street,number,locator,city,postalCode,email,website
 from Organization
 where id=$P{idOrg}]]></queryString>
 
 	<field name="name" class="java.lang.String"/>
-	<field name="cif" class="java.lang.String"/>
+	<field name="documentNumber" class="java.lang.String"/>
 	<field name="phone" class="java.lang.String"/>
 	<field name="street" class="java.lang.String"/>
 	<field name="number" class="java.lang.String"/>

--- a/tntconcept-web/src/main/templates/stajanov.organization.properties
+++ b/tntconcept-web/src/main/templates/stajanov.organization.properties
@@ -150,9 +150,9 @@ field.phone.name=Tel\u00e9fono
 field.phone.width=20%
 field.phone.editAttribs=maxlength="15"
 
-field.cif.name=CIF
-field.cif.ignoreInList=true
-field.cif.editAttribs=maxlength="50"
+field.documentNumber.name=CIF
+field.documentNumber.ignoreInList=true
+field.documentNumber.editAttribs=maxlength="50"
 
 field.street.name=Calle
 field.street.ignoreInList=true


### PR DESCRIPTION
Fixes bugs in the following informes:
- Bajas médicas
- Vacaciones aceptadas
- Vacaciones imputadas
- Vacaciones pendientes
- Vacaciones rechazadas
- Comparativo entre pendientes y aceptadas

This applies to stories with id: 176088750, 176088772, and 176088573.