### PR TITLE
Fixes outdated project bean bug when autocompleting project data

### DIFF
--- a/tntconcept-web/src/main/java/com/autentia/tnt/bean/admin/ProjectBean.java
+++ b/tntconcept-web/src/main/java/com/autentia/tnt/bean/admin/ProjectBean.java
@@ -63,6 +63,7 @@ public class ProjectBean extends BaseBean {
      */
 
     public String copy() {
+        project = null;
         int id = Integer.parseInt(FacesUtils.getRequestParameter(ROW_ID));
         copy(id);
         return NavigationResults.COPY_FROM_OFFER;
@@ -412,6 +413,7 @@ public class ProjectBean extends BaseBean {
      * @return forward to LIST page
      */
     public String list() {
+        project = null;
         offerNumberInput.setValue("");
         offerNumberList.clear();
         return NavigationResults.LIST;


### PR DESCRIPTION
Solves US #176088658

Copy and list methods did not reset the project correctly. Thus leading to the bean being outdated when autocompleting info for a different client.