### PR TITLE
Bump mysql-connector-java from 5.1.6 to 8.0.16 in /tntconcept-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,7 +443,14 @@
 		</dependencies>
 	</dependencyManagement>
 
+	<!-- MySQL database driver -->
 	<dependencies>
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>8.0.16</version>
+		</dependency>
+
 		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>

--- a/tntconcept-core/pom.xml
+++ b/tntconcept-core/pom.xml
@@ -136,12 +136,6 @@
 			<version>1.1.6</version>
 		</dependency>
 
-		<!-- MySQL database driver -->
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.9</version>
-		</dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/tntconcept-test/pom.xml
+++ b/tntconcept-test/pom.xml
@@ -21,7 +21,7 @@
         === descomentar para lanzar cargo en la fase de test ===
 
         mirar las siguientes URL para configurar el datasource en un tomcat arrancado con cargo:
-        
+
         http://cargo.codehaus.org/Starting+and+stopping+a+container
         http://209.85.229.132/search?q=cache:u0KiW4gGtK4J:blogs.atlassian.com/developer/2007/03/from_manual_to_automatic.html+maven+cargo+datasource&cd=1&hl=en&ct=clnk&gl=es&client=firefox-a
 
@@ -137,11 +137,6 @@
             <version>1.8.0.10</version>
             <scope>test</scope>
         </dependency>
-		<dependency>
-		    <groupId>mysql</groupId>
-		    <artifactId>mysql-connector-java</artifactId>
-		    <version>5.1.6</version>
-		    <scope>test</scope>
-		</dependency>         
+
     </dependencies>
 </project>


### PR DESCRIPTION
Cleaned repeated dependency of mysql-connector-java in tntconcept-core and tntconcept-test.
Dependency in tntconcept-parent now.
Updated version from 5.1.6 to 8.0.16