### PR TITLE
hotfix: fix-reset-password-email

### DIFF
--- a/src/main/install/config/autentia.properties
+++ b/src/main/install/config/autentia.properties
@@ -145,8 +145,3 @@ notWorkingTimeProjectIds = 1556
 
 # Variable para habilitar o deshabilitar el envio de correos de notificacion de evidencias
 sendMailNotificationEvidences = false
-
-#mail.host = smtp.gmail.com
-#mail.port = 465
-#mail.username = example@example.com
-#mail.password = password


### PR DESCRIPTION
Set tntconcept-url property as the url of the recover password email