### PR TITLE
fix: Restore setter and getter entity functionality

### DIFF
--- a/tntconcept-core/src/main/java/com/autentia/tnt/businessobject/Activity.java
+++ b/tntconcept-core/src/main/java/com/autentia/tnt/businessobject/Activity.java
@@ -81,11 +81,11 @@ public class Activity implements Serializable, ITransferObject {
     private Date end;
 
     public Date getEnd() {
-        return getEndDate();
+        return this.end;
     }
 
     public void setEnd(Date end) {
-        this.end = getEndDate();
+        this.end = end;
     }
 
 

--- a/tntconcept-web/src/test/java/com/autentia/tnt/bean/ActivityEvidenceNotificationBean_IT.java
+++ b/tntconcept-web/src/test/java/com/autentia/tnt/bean/ActivityEvidenceNotificationBean_IT.java
@@ -97,6 +97,7 @@ public class ActivityEvidenceNotificationBean_IT extends TestContainer {
         activity.setBillable(true);
         activity.setDescription("");
         activity.setHasEvidences(true);
+        activity.setEnd(activity.getEndDate());
 
         ActivityDAO activityDAO = (ActivityDAO) SpringUtils.getSpringBean("daoActivity");
         activityDAO.insert(activity);
@@ -109,11 +110,14 @@ public class ActivityEvidenceNotificationBean_IT extends TestContainer {
         activity.setDescription("Test activity 2");
         activity.setHasEvidences(true);
         activity.setStart(Date.from(LocalDate.now().plusDays(-4).atStartOfDay(ZoneId.systemDefault()).toInstant()));
-        activity.setRole(role);
         activity.setDuration(32);
+        activity.setEnd(activity.getEndDate());
+
+        activity.setRole(role);
         activity.setBillable(true);
         activity.setDescription("");
         activity.setHasEvidences(true);
+
 
 
         ActivityDAO activityDAO = (ActivityDAO) SpringUtils.getSpringBean("daoActivity");


### PR DESCRIPTION
Prevent a batch update in activities due to a not needed calculation of `end` field in `Activity`